### PR TITLE
Upgrade to RxJava2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 RxStore
 =====
 
-A tiny library that assists in saving and restoring objects to and from disk using [RxJava](https://github.com/ReactiveX/RxJava), and observing changes over time.
+A tiny library that assists in saving and restoring objects to and from disk using [RxJava2](https://github.com/ReactiveX/RxJava), and observing changes over time.
 
 Details
 -------
@@ -63,7 +63,7 @@ Perhaps you're making use of Square's [Retrofit](http://square.github.io/retrofi
 
 ```java
 webServices.getPerson()
-    .flatMap((person) -> store.put("person", person).toObservable())
+    .flatMap((person) -> store.observePut("person", person).toObservable())
     .subscribe((person) -> {
       // Do something with newly downloaded and persisted person.
     });
@@ -81,7 +81,7 @@ A `ListStore` that has been cleared or not yet given a value will return an immu
 
 ####Observing data
 
-Another handy trick is to observe a store change over time. Calling `store.asObservable()` will give you an rx `Observable`. This `Observable` will immediately deliver the current value of the store on subscription, and will then deliver updated values if changes occur in `onNext()`. `onCompleted()` will only be called if the store is deleted.
+Another handy trick is to observe a store change over time. Calling `store.asObservable()` will give you an rx `Observable`. This `Observable` will immediately deliver deliver updated values if changes occur in `onNext()`. `onCompleted()` will only be called if the store is deleted.
 
 Kotlin
 ------

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
 }
 
 ext {
-  rxJava = 'io.reactivex:rxjava:1.1.10'
+  rxJava = 'io.reactivex.rxjava2:rxjava:2.0.7'
   junit = 'junit:junit:4.12'
   truth = 'com.google.truth:truth:0.28'
   gson = 'com.google.code.gson:gson:2.6.2'

--- a/rxstore/src/main/java/au/com/gridstone/rxstore/ItemNotFoundException.java
+++ b/rxstore/src/main/java/au/com/gridstone/rxstore/ItemNotFoundException.java
@@ -1,0 +1,4 @@
+package au.com.gridstone.rxstore;
+
+public class ItemNotFoundException extends RuntimeException {
+}

--- a/rxstore/src/main/java/au/com/gridstone/rxstore/events/ListStoreEvent.java
+++ b/rxstore/src/main/java/au/com/gridstone/rxstore/events/ListStoreEvent.java
@@ -1,0 +1,70 @@
+package au.com.gridstone.rxstore.events;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListStoreEvent<T> {
+  private final List<T> list;
+  private final Type type;
+
+  private ListStoreEvent(Type type, List<T> list) {
+    this.type = type;
+    if (list != null)
+      this.list = new ArrayList<T>(list);
+    else
+      this.list = null;
+  }
+
+  public enum Type {
+    STORE_DELETED,
+    STORE_CLEARED,
+    LIST_PUT,
+    ITEM_ADDED,
+    ITEM_REMOVED,
+    ITEM_REPLACED
+  }
+
+  public static <T> ListStoreEvent<T> createStoreDeletedEvent() {
+    return new ListStoreEvent<T>(Type.STORE_DELETED, null);
+  }
+
+  public static <T> ListStoreEvent<T> createStoreClearedEvent() {
+    return new ListStoreEvent<T>(Type.STORE_CLEARED, null);
+  }
+
+  public static <T> ListStoreEvent<T> createListPutEvent(List<T> list) {
+    return new ListStoreEvent<T>(Type.LIST_PUT, list);
+  }
+
+  public static <T> ListStoreEvent<T> createItemAddedEvent(List<T> list) {
+    return new ListStoreEvent<T>(Type.ITEM_ADDED, list);
+  }
+
+  public static <T> ListStoreEvent<T> createItemRemovedEvent(List<T> list) {
+    return new ListStoreEvent<T>(Type.ITEM_REMOVED, list);
+  }
+
+  public static <T> ListStoreEvent createItemReplacedEvent(List<T> list) {
+    return new ListStoreEvent<T>(Type.ITEM_REPLACED, list);
+  }
+
+  /**
+   * @return the new list
+   * @throws IllegalStateException if {{@link #getType()}} is not {@link Type#LIST_PUT}, {@link Type#ITEM_ADDED},
+   *                               {@link Type#ITEM_REMOVED} or {@link Type#ITEM_REPLACED}
+   */
+  public List<T> getList() {
+    if (isGetListAllowed())
+      return list;
+
+    throw new IllegalStateException();
+  }
+
+  private boolean isGetListAllowed() {
+    return type == Type.LIST_PUT || type == Type.ITEM_ADDED || type == Type.ITEM_REMOVED || type == Type.ITEM_REPLACED;
+  }
+
+  public Type getType() {
+    return type;
+  }
+}

--- a/rxstore/src/main/java/au/com/gridstone/rxstore/events/StoreEvent.java
+++ b/rxstore/src/main/java/au/com/gridstone/rxstore/events/StoreEvent.java
@@ -1,0 +1,44 @@
+package au.com.gridstone.rxstore.events;
+
+public class StoreEvent<T> {
+  private final T item;
+  private final Type type;
+
+  private StoreEvent(Type type, T item) {
+    this.type = type;
+    this.item = item;
+  }
+
+  public enum Type {
+    STORE_DELETED,
+    STORE_CLEARED,
+    ITEM_PUT,
+  }
+
+  public static <T> StoreEvent<T> createStoreDeletedEvent() {
+    return new StoreEvent<T>(Type.STORE_DELETED, null);
+  }
+
+  public static <T> StoreEvent<T> createStoreClearedEvent() {
+    return new StoreEvent<T>(Type.STORE_CLEARED, null);
+  }
+
+  public static <T> StoreEvent<T> createItemPutEvent(T item) {
+    return new StoreEvent<T>(Type.ITEM_PUT, item);
+  }
+
+  /**
+   * @return the item
+   * @throws IllegalStateException if {{@link #getType()}} is not {@link Type#ITEM_PUT}
+   */
+  public T getItem() {
+    if (getType() == Type.ITEM_PUT)
+      return item;
+
+    throw new IllegalStateException();
+  }
+
+  public Type getType() {
+    return type;
+  }
+}

--- a/rxstore/src/test/java/au/com/gridstone/rxstore/testutil/RecordingObserver.java
+++ b/rxstore/src/test/java/au/com/gridstone/rxstore/testutil/RecordingObserver.java
@@ -1,22 +1,28 @@
 package au.com.gridstone.rxstore.testutil;
 
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+
 import java.util.NoSuchElementException;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-import rx.Observer;
 
 import static com.google.common.truth.Truth.assertThat;
 
 public final class RecordingObserver<T> implements Observer<T> {
   private final BlockingDeque<Object> events = new LinkedBlockingDeque<Object>();
 
-  @Override public void onCompleted() {
-    events.addLast(new OnCompleted());
+  @Override public void onComplete() {
+    events.addLast(new OnComplete());
   }
 
   @Override public void onError(Throwable e) {
     events.addLast(new OnError(e));
+  }
+
+  @Override public void onSubscribe(Disposable d) {
+    events.addLast(new OnSubscribe());
   }
 
   @Override public void onNext(T t) {
@@ -38,6 +44,11 @@ public final class RecordingObserver<T> implements Observer<T> {
     return wanted.cast(event);
   }
 
+  public OnSubscribe takeSubscribe() {
+    OnSubscribe event = takeEvent(OnSubscribe.class);
+    return event;
+  }
+
   public T takeNext() {
     OnNext event = takeEvent(OnNext.class);
     return event.value;
@@ -48,7 +59,7 @@ public final class RecordingObserver<T> implements Observer<T> {
   }
 
   public void assertOnCompleted() {
-    takeEvent(OnCompleted.class);
+    takeEvent(OnComplete.class);
   }
 
   public void assertNoMoreEvents() {
@@ -71,9 +82,15 @@ public final class RecordingObserver<T> implements Observer<T> {
     }
   }
 
-  private final class OnCompleted {
+  private final class OnComplete {
     @Override public String toString() {
-      return "OnCompleted";
+      return "OnComplete";
+    }
+  }
+
+  private final class OnSubscribe {
+    @Override public String toString() {
+      return "OnSubscribe";
     }
   }
 


### PR DESCRIPTION
As the library is incompatible with RxJava2 it should be updated to the newest version.

As RxJava2 disallows emitting `null` the API had to be adapted to this new design approach.
Instead of emitting `null` on the Observables the streams emit `StoreEvent` and `ListStoreEvent` respectively.

I am not sure if you want to merge this into RxStore or create a new project RxStore2 in any case it would be nice to get a RxJava2 compatible RxStore. 